### PR TITLE
feat: add --silent and --no-consent for non-interactive environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,43 @@ In SAFE mode, it simply runs the original Claude CLI without modifications.
 
 Sometimes you just want to YOLO and skip those pesky permission checks. But sometimes you want the safety checks back! This fork gives you the best of both worlds.
 
+## Environment Variables for CI / Container Use
+
+When running `claude-yolo` in non-interactive environments (Docker containers, CI pipelines, automated scripts), you can use environment variables to control startup behavior:
+
+| Variable | CLI flag | Effect |
+|----------|----------|--------|
+| `CLAUDE_YOLO_SILENT=1` | `--silent` | Suppress all startup banners (`[YOLO]`, `YOLO MODE ACTIVATED`, root bypass warning), mode indicators (`[SAFE]`), and npm update output (version checks, `npm install` progress) |
+| `CLAUDE_YOLO_SKIP_CONSENT=1` | `--no-consent` | Skip the interactive consent prompt and auto-accept. Also creates the consent flag file so subsequent runs won't prompt either |
+| `DEBUG=1` | — | Show debug output |
+
+All flags and environment variables can be freely combined. Here are common scenarios:
+
+```bash
+# Silent only — no banners, but still prompts for consent on first run
+claude-yolo --silent
+
+# Skip consent only — shows banners, but auto-accepts consent
+claude-yolo --no-consent
+
+# Both — fully non-interactive, no output noise
+claude-yolo --silent --no-consent
+
+# Same with env vars (better for Dockerfiles and CI)
+CLAUDE_YOLO_SILENT=1 CLAUDE_YOLO_SKIP_CONSENT=1 claude-yolo
+
+# Mix and match — env var for one, flag for the other
+CLAUDE_YOLO_SILENT=1 claude-yolo --no-consent
+```
+
+### Dockerfile example
+
+```dockerfile
+ENV CLAUDE_YOLO_SILENT=1
+ENV CLAUDE_YOLO_SKIP_CONSENT=1
+RUN npm install -g claude-yolo
+```
+
 ## Debugging
 
 If you encounter any issues, you can run with debug output:

--- a/postinstall.js
+++ b/postinstall.js
@@ -9,6 +9,11 @@ const CYAN = '\x1b[36m';
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
 
+// Skip consent prompt when env var is set (for CI/container use)
+if (process.env.CLAUDE_YOLO_SKIP_CONSENT === '1' || process.env.CLAUDE_YOLO_SKIP_CONSENT === 'true') {
+  process.exit(0);
+}
+
 // Create readline interface for user input
 const rl = readline.createInterface({
   input: process.stdin,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                               
  Adds two new controls for running claude-yolo in non-interactive environments (Docker containers, CI pipelines, automated scripts):                                                                                                                                          
                                                            
  - **`--silent` / `CLAUDE_YOLO_SILENT=1`** — Suppresses all startup banners (`[YOLO]`, `YOLO MODE ACTIVATED`, root bypass warning, `[SAFE]` indicator) and npm update output
  - **`--no-consent` / `CLAUDE_YOLO_SKIP_CONSENT=1`** — Skips the interactive consent prompt and auto-creates the consent flag file

  Both are available as CLI flags and environment variables, and can be freely combined.

  ## Motivation

  Currently, using claude-yolo in containers requires hacky workarounds — piping `echo "yes"` into the process and manually creating `.claude-yolo-consent` flag files. The startup banners also produce unwanted noise in automated environments. This was requested in #6.

  ## Changes

  - **`bin/claude-yolo.js`** — Added `isSilent` and `skipConsent` checks; wrapped all banner output in `if (!isSilent)` guards; auto-consent logic when `skipConsent` is set; both flags stripped from argv before passing to Claude CLI
  - **`postinstall.js`** — Early exit when `CLAUDE_YOLO_SKIP_CONSENT` is set
  - **`README.md`** — New "Environment Variables for CI / Container Use" section with usage examples

  ## Test plan

  | Scenario | Result |
  |---|---|
  | No flags (default) | Shows banners + consent prompt |
  | `--silent` only | No banners, consent still prompts if needed |
  | `--no-consent` only | Banners show, consent auto-accepted |
  | `--silent --no-consent` | Fully silent, no interaction |
  | `CLAUDE_YOLO_SILENT=1 CLAUDE_YOLO_SKIP_CONSENT=1` | Same via env vars |
  | Fresh install + `--no-consent` | Consent flag auto-created |
  | `--safe --silent` | No `[SAFE]` banner |
  | Forced npm update + `--silent` | Update runs silently |
  | Flags don't leak to Claude CLI | `--help` output clean |

  Closes #6
