### PR TITLE
fix: use pathToFileURL for ESM dynamic import on Windows

### DIFF
--- a/bin/claude-yolo.js
+++ b/bin/claude-yolo.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { createRequire } from 'module';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { execSync } from 'child_process';
 import readline from 'readline';
 
@@ -252,7 +252,7 @@ async function run() {
     }
     
     // Run original CLI without modifications
-    await import(originalCliPath);
+    await import(pathToFileURL(originalCliPath));
     return; // Exit early
   }
 
@@ -395,7 +395,7 @@ async function run() {
   debug("Added --dangerously-skip-permissions flag to command line arguments");
 
   // Now import the modified CLI
-  await import(yoloCliPath);
+  await import(pathToFileURL(yoloCliPath));
 }
 
 // Run the main function


### PR DESCRIPTION
## Summary

- Import `pathToFileURL` from the `url` module
- Wrap dynamic `import()` calls with `pathToFileURL()` to fix Windows ESM compatibility

## Fix

On Windows, dynamic `import()` requires `file://` URL format instead of absolute paths like `E:\npm-global\...`. The fix wraps two `import()` calls:

1. **Line 8**: Added `pathToFileURL` to imports
2. **Line 255**: Safe mode - `await import(pathToFileURL(originalCliPath))`
3. **Line 398**: YOLO mode - `await import(pathToFileURL(yoloCliPath))`

## Test plan

- [ ] Verify `--safe` mode works on Windows
- [ ] Verify YOLO mode works on Windows

Fixes #9